### PR TITLE
add static libz library

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on: push
 
 env:
   QT_VERSION: "v6.3.1"
+  ZLIB_VERSION: "v1.2.12" # not used for msvc builds
 
 jobs:
   linux:

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@
 set -e -x
 
 echo "QT_VERSION = $QT_VERSION"
+echo "ZLIB_VERSION: ${ZLIB_VERSION}"
 echo "INSTALL_PREFIX = $INSTALL_PREFIX"
 echo "SUDO_CMD = $SUDO_CMD"
 echo "CONFIGURE_EXTRAS = $CONFIGURE_EXTRAS"
@@ -13,6 +14,31 @@ g++ --version
 # make qt dir
 mkdir qt
 cd qt
+
+# build static version of zlib to use instead of Qt bundled version
+# to allow other libraries to link to the same zlib version
+git clone -b $ZLIB_VERSION --depth 1 https://github.com/madler/zlib.git
+cd zlib
+mkdir build
+cd build
+cmake -G "Ninja" .. \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET="10.14" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_C_FLAGS="-fpic -fvisibility=hidden" \
+    -DCMAKE_CXX_FLAGS="-fpic -fvisibility=hidden" \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX"
+time ninja zlibstatic
+# manual install to avoid shared libs being installed & issues with compiling example programs
+# wildcard is used because on mingw it calls the library file libzlibstatic.a for some reason:
+$SUDO_CMD mkdir -p $INSTALL_PREFIX
+$SUDO_CMD mkdir -p $INSTALL_PREFIX/lib
+$SUDO_CMD mkdir -p $INSTALL_PREFIX/include
+$SUDO_CMD cp libz*.a $INSTALL_PREFIX/lib/libz.a
+$SUDO_CMD cp zconf.h $INSTALL_PREFIX/include/.
+$SUDO_CMD cp ../zlib.h $INSTALL_PREFIX/include/.
+cd ../../
+
 
 # download Qt sources to qt/qt5
 git clone https://code.qt.io/qt/qt5.git
@@ -37,7 +63,9 @@ cmake ../qt5/qtbase -G "Ninja" \
     -DFEATURE_system_png=OFF \
     -DFEATURE_system_proxies=OFF \
     -DFEATURE_system_textmarkdownreader=OFF \
-    -DFEATURE_system_zlib=OFF \
+    -DFEATURE_system_zlib=ON \
+    -DZLIB_INCLUDE_DIR=${INSTALL_PREFIX}/include \
+    -DZLIB_LIBRARY_RELEASE=${INSTALL_PREFIX}/lib/libz.a \
     -DFEATURE_zstd=OFF \
     -DFEATURE_openssl=OFF \
     -DFEATURE_sql=OFF \


### PR DESCRIPTION
- on linux/osx/mingw build static libz
- link Qt to this instead of using the bundled Qt version
- allows other libs to also link to the same libz library
  - Qt bundled version has modified headers that include other Qt stuff
